### PR TITLE
[wip] makes it possible to run alpaca with flyte

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-ARG PYTHON_VERSION
-FROM python:3.9-slim-buster
+FROM pytorch/pytorch:2.0.0-cuda11.7-cudnn8-runtime
 
-MAINTAINER Union AI Team 
 LABEL org.opencontainers.image.source https://github.com/unionai-oss/stanford-alpaca
 
 WORKDIR /root
+ENV VENV /opt/venv
+ENV LANG C.UTF-8
+ENV LC_ALL C.UTF-8
 ENV PYTHONPATH /root
 
 ARG VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+ARG PYTHON_VERSION
+FROM python:3.9-slim-buster
+
+MAINTAINER Union AI Team 
+LABEL org.opencontainers.image.source https://github.com/unionai-oss/stanford-alpaca
+
+WORKDIR /root
+ENV PYTHONPATH /root
+
+ARG VERSION
+ARG DOCKER_IMAGE
+
+RUN apt-get update && apt-get install build-essential -y
+
+COPY . /root
+
+WORKDIR /root
+# Pod tasks should be exposed in the default image
+RUN pip install -r requirements.txt
+
+ENV FLYTE_INTERNAL_IMAGE "$DOCKER_IMAGE"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ torch
 sentencepiece
 tokenizers==0.12.1
 wandb
+https://github.com/flyteorg/flyteidl/archive/e435d9146a36c94e8ee8acd193063485c2da89aa.zip#egg=flyteidl
+https://github.com/flyteorg/flytekit/archive/fd918fb799aab2c4c4a35722fee9459be8197b83.zip#egg=flytekit

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ sentencepiece
 tokenizers==0.12.1
 wandb
 https://github.com/flyteorg/flyteidl/archive/e435d9146a36c94e8ee8acd193063485c2da89aa.zip#egg=flyteidl
-https://github.com/flyteorg/flytekit/archive/fd918fb799aab2c4c4a35722fee9459be8197b83.zip#egg=flytekit
+https://github.com/flyteorg/flytekit/archive/e97780b25b6539b302876bf68e5a94f96d3fb9b8.zip#egg=flytekit
+https://github.com/flyteorg/flytekit/archive/e97780b25b6539b302876bf68e5a94f96d3fb9b8.zip#subdirectory=plugins/flytekit-kf-pytorch&egg=flytekitplugins-kfpytorch

--- a/train.py
+++ b/train.py
@@ -196,7 +196,7 @@ def make_supervised_data_module(tokenizer: transformers.PreTrainedTokenizer, dat
     return dict(train_dataset=train_dataset, eval_dataset=None, data_collator=data_collator)
 
 
-@flytekit.task(task_config=Elastic(), requests=Resources(gpu="1", mem="32Gi", cpu="4"))
+@flytekit.task(task_config=Elastic(), environment={"TRANSFORMERS_CACHE": "/tmp"})  # requests=Resources(gpu="1", mem="32Gi", cpu="4"))
 def train(model_args: ModelArguments, data_args: DataArguments, training_args: TrainingArguments):
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,

--- a/train.py
+++ b/train.py
@@ -19,12 +19,13 @@ from typing import Optional, Dict, Sequence
 
 import torch
 import transformers
+from flytekit import Resources
 from torch.utils.data import Dataset
 from transformers import Trainer
 
 import utils
 import flytekit
-from flytekitplugins.torchelastic.task import Elastic
+from flytekitplugins.kfpytorch.task import Elastic
 from dataclasses_json import dataclass_json
 
 IGNORE_INDEX = -100
@@ -195,7 +196,7 @@ def make_supervised_data_module(tokenizer: transformers.PreTrainedTokenizer, dat
     return dict(train_dataset=train_dataset, eval_dataset=None, data_collator=data_collator)
 
 
-@flytekit.task(task_config=Elastic())
+@flytekit.task(task_config=Elastic(), requests=Resources(gpu="1", mem="32Gi", cpu="4"))
 def train(model_args: ModelArguments, data_args: DataArguments, training_args: TrainingArguments):
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,

--- a/train.py
+++ b/train.py
@@ -23,6 +23,9 @@ from torch.utils.data import Dataset
 from transformers import Trainer
 
 import utils
+import flytekit
+from flytekitplugins.torchelastic.task import Elastic
+from dataclasses_json import dataclass_json
 
 IGNORE_INDEX = -100
 DEFAULT_PAD_TOKEN = "[PAD]"
@@ -43,16 +46,19 @@ PROMPT_DICT = {
 }
 
 
+@dataclass_json
 @dataclass
 class ModelArguments:
     model_name_or_path: Optional[str] = field(default="facebook/opt-125m")
 
 
+@dataclass_json
 @dataclass
 class DataArguments:
     data_path: str = field(default=None, metadata={"help": "Path to the training data."})
 
 
+@dataclass_json
 @dataclass
 class TrainingArguments(transformers.TrainingArguments):
     cache_dir: Optional[str] = field(default=None)
@@ -189,10 +195,8 @@ def make_supervised_data_module(tokenizer: transformers.PreTrainedTokenizer, dat
     return dict(train_dataset=train_dataset, eval_dataset=None, data_collator=data_collator)
 
 
-def train():
-    parser = transformers.HfArgumentParser((ModelArguments, DataArguments, TrainingArguments))
-    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
-
+@flytekit.task(task_config=Elastic())
+def train(model_args: ModelArguments, data_args: DataArguments, training_args: TrainingArguments):
     model = transformers.AutoModelForCausalLM.from_pretrained(
         model_args.model_name_or_path,
         cache_dir=training_args.cache_dir,
@@ -225,6 +229,12 @@ def train():
     trainer.train()
     trainer.save_state()
     safe_save_model_for_hf_trainer(trainer=trainer, output_dir=training_args.output_dir)
+
+
+def train_cli():
+    parser = transformers.HfArgumentParser((ModelArguments, DataArguments, TrainingArguments))
+    model_args, data_args, training_args = parser.parse_args_into_dataclasses()
+    train(model_args, data_args, training_args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Local

To execute locally you have to `export PYTHONPATH=.:$PYTHONPATH` to let flytekit find all the modules :(

```bash
pyflyte run train.py train --model_args='{}' --data_args='{"data_path":"./alpaca_data.json"}' --training_args='{"output_dir":"/tmp"}'
```

### Execute on Flyte Cluster

Here's an example command that uses the StableLM 3B model:

```
pyflyte --config ~/.flyte/uniondemo-config.yaml run --remote --image nielsbantilan/flytekit-alpaca-gpu:latest train.py train_wf --model_args='{"model_name_or_path": "stabilityai/stablelm-tuned-alpha-3b"}' --data_args='{"data_path":"./alpaca_data.json"}' --training_args='{"output_dir":"/tmp", "num_train_epochs": 1, "per_device_train_batch_size": 1, "per_device_eval_batch_size": 1, "gradient_accumulation_steps": 16, "evaluation_strategy": "no", "save_strategy": "steps", "save_steps": 2000, "save_total_limit": 1, "learning_rate": 0.00002, "weight_decay": 0.0, "warmup_ratio": 0.03, "lr_scheduler_type": "cosine", "logging_steps": 1, "no_cuda": false, "half_precision_backend": "auto", "report_to": ["wandb"]}'
```
